### PR TITLE
small tweaks, fixes

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -8,6 +8,7 @@
             "name": "@packages/client",
             "version": "1.0.0",
             "workspaces": [
+                "../packages/business",
                 "../packages/user",
                 "../packages/util"
             ],
@@ -23,6 +24,12 @@
             "name": "@packages/aws",
             "version": "1.0.0",
             "extraneous": true
+        },
+        "../packages/business": {
+            "version": "1.0.0",
+            "peerDependencies": {
+                "@packages/util": "file:../util"
+            }
         },
         "../packages/user": {
             "name": "@packages/user",
@@ -301,6 +308,10 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@packages/business": {
+            "resolved": "../packages/business",
+            "link": true
+        },
         "node_modules/@packages/user": {
             "resolved": "../packages/user",
             "link": true
@@ -462,6 +473,28 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-dom": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+            "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+            "peer": true,
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+            "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+            "peer": true,
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -568,11 +601,17 @@
             "integrity": "sha512-4ZEwiRuZEicXhXqmhw3+de8Z4EpOLQj/gp+D9fFWo6ii6W1kBkNNvvEx4A90ugppu+74pT1lIJnOuz3A9oQeJA==",
             "optional": true
         },
+        "@packages/business": {
+            "version": "file:../packages/business",
+            "requires": {}
+        },
         "@packages/user": {
-            "version": "file:../packages/user"
+            "version": "file:../packages/user",
+            "requires": {}
         },
         "@packages/util": {
-            "version": "file:../packages/util"
+            "version": "file:../packages/util",
+            "requires": {}
         },
         "@types/prop-types": {
             "version": "15.7.5",
@@ -672,6 +711,25 @@
                 "loose-envify": "^1.1.0"
             }
         },
+        "react-dom": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+            "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+            "peer": true,
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.0"
+            }
+        },
+        "scheduler": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+            "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+            "peer": true,
+            "requires": {
+                "loose-envify": "^1.1.0"
+            }
+        },
         "source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -680,7 +738,8 @@
         "styled-jsx": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-            "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ=="
+            "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+            "requires": {}
         }
     }
 }

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -27,18 +27,11 @@
         },
         "../packages/business": {
             "name": "@packages/business",
-            "version": "1.0.0",
-            "peerDependencies": {
-                "@packages/util": "file:../util"
-            }
+            "version": "1.0.0"
         },
         "../packages/user": {
             "name": "@packages/user",
-            "version": "1.0.0",
-            "peerDependencies": {
-                "@packages/business": "file:../business",
-                "@packages/util": "file:../util"
-            }
+            "version": "1.0.0"
         },
         "../packages/user2": {
             "name": "@packages/user2",
@@ -120,10 +113,7 @@
         },
         "../packages/util": {
             "name": "@packages/util",
-            "version": "1.0.0",
-            "peerDependencies": {
-                "@packages/aws": "file:../aws"
-            }
+            "version": "1.0.0"
         },
         "node_modules/@next/env": {
             "version": "12.1.6",

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -26,6 +26,7 @@
             "extraneous": true
         },
         "../packages/business": {
+            "name": "@packages/business",
             "version": "1.0.0",
             "peerDependencies": {
                 "@packages/util": "file:../util"
@@ -35,6 +36,7 @@
             "name": "@packages/user",
             "version": "1.0.0",
             "peerDependencies": {
+                "@packages/business": "file:../business",
                 "@packages/util": "file:../util"
             }
         },
@@ -473,28 +475,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-dom": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-            "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.0"
-            },
-            "peerDependencies": {
-                "react": "^18.2.0"
-            }
-        },
-        "node_modules/scheduler": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-            "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            }
-        },
         "node_modules/source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -602,16 +582,13 @@
             "optional": true
         },
         "@packages/business": {
-            "version": "file:../packages/business",
-            "requires": {}
+            "version": "file:../packages/business"
         },
         "@packages/user": {
-            "version": "file:../packages/user",
-            "requires": {}
+            "version": "file:../packages/user"
         },
         "@packages/util": {
-            "version": "file:../packages/util",
-            "requires": {}
+            "version": "file:../packages/util"
         },
         "@types/prop-types": {
             "version": "15.7.5",
@@ -711,25 +688,6 @@
                 "loose-envify": "^1.1.0"
             }
         },
-        "react-dom": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-            "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-            "peer": true,
-            "requires": {
-                "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.0"
-            }
-        },
-        "scheduler": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-            "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-            "peer": true,
-            "requires": {
-                "loose-envify": "^1.1.0"
-            }
-        },
         "source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -738,8 +696,7 @@
         "styled-jsx": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-            "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-            "requires": {}
+            "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ=="
         }
     }
 }

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -4,6 +4,7 @@
     "lockfileVersion": 2,
     "description": "Client",
     "workspaces": [
+        "../packages/business",
         "../packages/user",
         "../packages/util"
     ],

--- a/src/client/pages/Test.tsx
+++ b/src/client/pages/Test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BusinessClasss } from '@packages/business';
+import { BusinessClass } from '@packages/business';
 import { UtiLClass } from '@packages/util';
 import { UserClass } from '@packages/user';
 import MyModel from 'server/product/model';
@@ -15,7 +15,7 @@ const Page = ({ prop }: Props): React.ReactElement => {
 };
 
 Page.getInitialProps = async ({ req }) => {
-    const business = new BusinessClasss();
+    const business = new BusinessClass();
     const util = new UtiLClass();
     const r = util.test();
     return {

--- a/src/client/pages/Test.tsx
+++ b/src/client/pages/Test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BusinessClasss } from '@packages/business';
 import { UtiLClass } from '@packages/util';
 import { UserClass } from '@packages/user';
 import MyModel from 'server/product/model';
@@ -14,6 +15,7 @@ const Page = ({ prop }: Props): React.ReactElement => {
 };
 
 Page.getInitialProps = async ({ req }) => {
+    const business = new BusinessClasss();
     const util = new UtiLClass();
     const r = util.test();
     return {

--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -17,6 +17,10 @@
             "server/*": ["../server/dist/esm/*"]
         }
     },
-    "references": [{ "path": "../packages/user" }, { "path": "../packages/util" }],
+    "references": [
+        { "path": "../packages/business" },
+        { "path": "../packages/user" },
+        { "path": "../packages/util" }
+    ],
     "include": ["**/*"]
 }

--- a/src/packages/business/package-lock.json
+++ b/src/packages/business/package-lock.json
@@ -12,6 +12,7 @@
             }
         },
         "../util": {
+            "name": "@packages/util",
             "version": "1.0.0",
             "peer": true,
             "peerDependencies": {

--- a/src/packages/business/package-lock.json
+++ b/src/packages/business/package-lock.json
@@ -1,23 +1,17 @@
 {
-    "name": "@packages/user",
+    "name": "@packages/business",
     "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@packages/user",
+            "name": "@packages/business",
             "version": "1.0.0",
             "peerDependencies": {
                 "@packages/util": "file:../util"
             }
         },
-        "../aws": {
-            "name": "@packages/aws",
-            "version": "1.0.0",
-            "extraneous": true
-        },
         "../util": {
-            "name": "@packages/util",
             "version": "1.0.0",
             "peer": true,
             "peerDependencies": {

--- a/src/packages/business/package-lock.json
+++ b/src/packages/business/package-lock.json
@@ -6,28 +6,12 @@
     "packages": {
         "": {
             "name": "@packages/business",
-            "version": "1.0.0",
-            "peerDependencies": {
-                "@packages/util": "file:../util"
-            }
+            "version": "1.0.0"
         },
         "../util": {
             "name": "@packages/util",
             "version": "1.0.0",
-            "peer": true,
-            "peerDependencies": {
-                "@packages/aws": "file:../aws"
-            }
-        },
-        "node_modules/@packages/util": {
-            "resolved": "../util",
-            "link": true
-        }
-    },
-    "dependencies": {
-        "@packages/util": {
-            "version": "file:../util",
-            "requires": {}
+            "extraneous": true
         }
     }
 }

--- a/src/packages/business/package.json
+++ b/src/packages/business/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@packages/user",
+    "name": "@packages/business",
     "version": "1.0.0",
     "lockfileVersion": 2,
     "main": "dist/index.js",

--- a/src/packages/business/package.json
+++ b/src/packages/business/package.json
@@ -6,8 +6,5 @@
     "types": "dist/index.d.ts",
     "scripts": {
         "compile": "tsc -b tsconfig.esm.json tsconfig.json"
-    },
-    "peerDependencies": {
-        "@packages/util": "file:../util"
     }
 }

--- a/src/packages/business/src/BusinessClass.ts
+++ b/src/packages/business/src/BusinessClass.ts
@@ -1,27 +1,25 @@
 import S3 from 'aws-sdk/clients/s3';
-import rekognition from 'aws-sdk/clients/rekognition'
+import rekognition from 'aws-sdk/clients/rekognition';
 
-import {UtiLClass} from '@packages/util';
+import { UtiLClass } from '@packages/util';
 import { ExpressReceiver, UnknownError } from '@slack/bolt';
 
 const s3 = new S3({
     credentialProvider: undefined,
 });
 
-
-
-class UserClass {
+class BusinessClasss {
     constructor() {}
 
     async loader() {
         s3.deleteBucket();
         s3.headBucket();
-        s3.upload({ Bucket: '', Key: ''});
+        s3.upload({ Bucket: '', Key: '' });
         const util = new UtiLClass();
         const recog = new rekognition();
-        const receiver = new ExpressReceiver({ signingSecret: ''});
+        const receiver = new ExpressReceiver({ signingSecret: '' });
         await util.test();
     }
 }
 
-export default UserClass;
+export default BusinessClasss;

--- a/src/packages/business/src/BusinessClass.ts
+++ b/src/packages/business/src/BusinessClass.ts
@@ -8,7 +8,7 @@ const s3 = new S3({
     credentialProvider: undefined,
 });
 
-class BusinessClasss {
+class BusinessClass {
     constructor() {}
 
     async loader() {
@@ -22,4 +22,4 @@ class BusinessClasss {
     }
 }
 
-export default BusinessClasss;
+export default BusinessClass;

--- a/src/packages/business/src/index.ts
+++ b/src/packages/business/src/index.ts
@@ -1,4 +1,3 @@
-import UserClass from './UserClass';
+import BusinessClasss from './BusinessClass';
 
-
-export { UserClass };
+export { BusinessClasss };

--- a/src/packages/business/src/index.ts
+++ b/src/packages/business/src/index.ts
@@ -1,3 +1,3 @@
-import BusinessClasss from './BusinessClass';
+import BusinessClass from './BusinessClass';
 
-export { BusinessClasss };
+export { BusinessClass };

--- a/src/packages/business/tsconfig.esm.json
+++ b/src/packages/business/tsconfig.esm.json
@@ -4,6 +4,6 @@
         "module": "esnext",
         "outDir": "dist/esm"
     },
-    "exclude": ["dist/", "node_modules/", "src/**/*.*.test.*"],
+    "exclude": ["dist/", "node_modules/"],
     "references": [{ "path": "../util/tsconfig.esm.json" }]
 }

--- a/src/packages/user/package-lock.json
+++ b/src/packages/user/package-lock.json
@@ -6,11 +6,7 @@
     "packages": {
         "": {
             "name": "@packages/user",
-            "version": "1.0.0",
-            "peerDependencies": {
-                "@packages/business": "file:../business",
-                "@packages/util": "file:../util"
-            }
+            "version": "1.0.0"
         },
         "../aws": {
             "name": "@packages/aws",
@@ -18,8 +14,9 @@
             "extraneous": true
         },
         "../business": {
+            "name": "@packages/business",
             "version": "1.0.0",
-            "peer": true,
+            "extraneous": true,
             "peerDependencies": {
                 "@packages/util": "file:../util"
             }
@@ -27,28 +24,10 @@
         "../util": {
             "name": "@packages/util",
             "version": "1.0.0",
-            "peer": true,
+            "extraneous": true,
             "peerDependencies": {
                 "@packages/aws": "file:../aws"
             }
-        },
-        "node_modules/@packages/business": {
-            "resolved": "../business",
-            "link": true
-        },
-        "node_modules/@packages/util": {
-            "resolved": "../util",
-            "link": true
-        }
-    },
-    "dependencies": {
-        "@packages/business": {
-            "version": "file:../business",
-            "requires": {}
-        },
-        "@packages/util": {
-            "version": "file:../util",
-            "requires": {}
         }
     }
 }

--- a/src/packages/user/package-lock.json
+++ b/src/packages/user/package-lock.json
@@ -8,6 +8,7 @@
             "name": "@packages/user",
             "version": "1.0.0",
             "peerDependencies": {
+                "@packages/business": "file:../business",
                 "@packages/util": "file:../util"
             }
         },
@@ -15,6 +16,13 @@
             "name": "@packages/aws",
             "version": "1.0.0",
             "extraneous": true
+        },
+        "../business": {
+            "version": "1.0.0",
+            "peer": true,
+            "peerDependencies": {
+                "@packages/util": "file:../util"
+            }
         },
         "../util": {
             "name": "@packages/util",
@@ -24,12 +32,20 @@
                 "@packages/aws": "file:../aws"
             }
         },
+        "node_modules/@packages/business": {
+            "resolved": "../business",
+            "link": true
+        },
         "node_modules/@packages/util": {
             "resolved": "../util",
             "link": true
         }
     },
     "dependencies": {
+        "@packages/business": {
+            "version": "file:../business",
+            "requires": {}
+        },
         "@packages/util": {
             "version": "file:../util",
             "requires": {}

--- a/src/packages/user/package.json
+++ b/src/packages/user/package.json
@@ -8,6 +8,7 @@
         "compile": "tsc -b tsconfig.esm.json tsconfig.json"
     },
     "peerDependencies": {
+        "@packages/business": "file:../business",
         "@packages/util": "file:../util"
     }
 }

--- a/src/packages/user/package.json
+++ b/src/packages/user/package.json
@@ -6,9 +6,5 @@
     "types": "dist/index.d.ts",
     "scripts": {
         "compile": "tsc -b tsconfig.esm.json tsconfig.json"
-    },
-    "peerDependencies": {
-        "@packages/business": "file:../business",
-        "@packages/util": "file:../util"
     }
 }

--- a/src/packages/user/src/index.ts
+++ b/src/packages/user/src/index.ts
@@ -1,0 +1,3 @@
+import UserClass from './operations/UserClass';
+
+export { UserClass };

--- a/src/packages/user/src/operations/UserClass.ts
+++ b/src/packages/user/src/operations/UserClass.ts
@@ -1,14 +1,13 @@
 import S3 from 'aws-sdk/clients/s3';
-import rekognition from 'aws-sdk/clients/rekognition'
+import rekognition from 'aws-sdk/clients/rekognition';
 
-import {UtiLClass} from '@packages/util';
+import { UtiLClass, Optional } from '@packages/util/core';
+import { BusinessClass } from '@packages/business';
 import { ExpressReceiver, UnknownError } from '@slack/bolt';
 
 const s3 = new S3({
     credentialProvider: undefined,
 });
-
-
 
 class UserClass {
     constructor() {}
@@ -16,11 +15,15 @@ class UserClass {
     async loader() {
         s3.deleteBucket();
         s3.headBucket();
-        s3.upload({ Bucket: '', Key: ''});
+        s3.upload({ Bucket: '', Key: '' });
         const util = new UtiLClass();
         const recog = new rekognition();
-        const receiver = new ExpressReceiver({ signingSecret: ''});
+        const receiver = new ExpressReceiver({ signingSecret: '' });
         await util.test();
+    }
+
+    userMethod(): Optional<BusinessClass> {
+        return Optional.empty();
     }
 }
 

--- a/src/packages/user/src/operations/index.ts
+++ b/src/packages/user/src/operations/index.ts
@@ -1,4 +1,0 @@
-import UserClass from './UserClass';
-
-
-export { UserClass };

--- a/src/packages/user/tsconfig.esm.json
+++ b/src/packages/user/tsconfig.esm.json
@@ -5,5 +5,8 @@
         "outDir": "dist/esm"
     },
     "exclude": ["dist/", "node_modules/", "src/**/*.*.test.*"],
-    "references": [{ "path": "../util/tsconfig.esm.json" }]
+    "references": [
+        { "path": "../business/tsconfig.esm.json" },
+        { "path": "../util/tsconfig.esm.json" }
+    ]
 }

--- a/src/packages/user/tsconfig.json
+++ b/src/packages/user/tsconfig.json
@@ -5,5 +5,5 @@
         "outDir": "dist/",
         "rootDir": "src/"
     },
-    "references": [{ "path": "../util" }]
+    "references": [{ "path": "../business" }, { "path": "../util" }]
 }

--- a/src/packages/util/package-lock.json
+++ b/src/packages/util/package-lock.json
@@ -6,24 +6,12 @@
     "packages": {
         "": {
             "name": "@packages/util",
-            "version": "1.0.0",
-            "peerDependencies": {
-                "@packages/aws": "file:../aws"
-            }
+            "version": "1.0.0"
         },
         "../aws": {
             "name": "@packages/aws",
             "version": "1.0.0",
-            "peer": true
-        },
-        "node_modules/@packages/aws": {
-            "resolved": "../aws",
-            "link": true
-        }
-    },
-    "dependencies": {
-        "@packages/aws": {
-            "version": "file:../aws"
+            "extraneous": true
         }
     }
 }

--- a/src/packages/util/package.json
+++ b/src/packages/util/package.json
@@ -15,6 +15,7 @@
             "import": "./dist/esm/core/index.js"
         }
     },
+    "types": "dist/index.d.ts",
     "typesVersions": {
         "*": {
             "*": [

--- a/src/packages/util/package.json
+++ b/src/packages/util/package.json
@@ -25,8 +25,5 @@
                 "./dist/core/index.d.ts"
             ]
         }
-    },
-    "peerDependencies": {
-        "@packages/aws": "file:../aws"
     }
 }

--- a/src/packages/util/src/core/Optional.ts
+++ b/src/packages/util/src/core/Optional.ts
@@ -1,0 +1,9 @@
+class Optional<T> {
+    private constructor(private value: T) {}
+
+    static empty<T>(): Optional<T> {
+        return new Optional(null);
+    }
+}
+
+export default Optional;

--- a/src/packages/util/src/core/client.ts
+++ b/src/packages/util/src/core/client.ts
@@ -1,4 +1,4 @@
 import UtiLClass from './util';
+import Optional from './Optional';
 
-
-export { UtiLClass };
+export { UtiLClass, Optional };

--- a/src/packages/util/src/core/index.ts
+++ b/src/packages/util/src/core/index.ts
@@ -1,0 +1,1 @@
+export * from './client';

--- a/src/packages/util/src/core/util.ts
+++ b/src/packages/util/src/core/util.ts
@@ -6,12 +6,15 @@ const s3 = new S3({
     credentialProvider: creds,
 });
 
-
-class UtiLClass {
-    constructor() {};
+class UtiLClass<T> {
+    constructor() {}
     async test() {
-        const receiver = new ExpressReceiver({ signingSecret: ''});
+        const receiver = new ExpressReceiver({ signingSecret: '' });
         s3.getObject(undefined);
+    }
+
+    get(): T {
+        throw Error();
     }
 }
 

--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -20,18 +20,11 @@
         },
         "../packages/business": {
             "name": "@packages/business",
-            "version": "1.0.0",
-            "peerDependencies": {
-                "@packages/util": "file:../util"
-            }
+            "version": "1.0.0"
         },
         "../packages/user": {
             "name": "@packages/user",
-            "version": "1.0.0",
-            "peerDependencies": {
-                "@packages/business": "file:../business",
-                "@packages/util": "file:../util"
-            }
+            "version": "1.0.0"
         },
         "../packages/user2": {
             "name": "@packages/user2",
@@ -113,10 +106,7 @@
         },
         "../packages/util": {
             "name": "@packages/util",
-            "version": "1.0.0",
-            "peerDependencies": {
-                "@packages/aws": "file:../aws"
-            }
+            "version": "1.0.0"
         },
         "node_modules/@packages/aws": {
             "resolved": "../packages/aws",
@@ -375,16 +365,13 @@
             "version": "file:../packages/aws"
         },
         "@packages/business": {
-            "version": "file:../packages/business",
-            "requires": {}
+            "version": "file:../packages/business"
         },
         "@packages/user": {
-            "version": "file:../packages/user",
-            "requires": {}
+            "version": "file:../packages/user"
         },
         "@packages/util": {
-            "version": "file:../packages/util",
-            "requires": {}
+            "version": "file:../packages/util"
         },
         "@slack/logger": {
             "version": "3.0.0",

--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -18,10 +18,18 @@
             "name": "@packages/aws",
             "version": "1.0.0"
         },
+        "../packages/business": {
+            "name": "@packages/business",
+            "version": "1.0.0",
+            "peerDependencies": {
+                "@packages/util": "file:../util"
+            }
+        },
         "../packages/user": {
             "name": "@packages/user",
             "version": "1.0.0",
             "peerDependencies": {
+                "@packages/business": "file:../business",
                 "@packages/util": "file:../util"
             }
         },
@@ -112,6 +120,10 @@
         },
         "node_modules/@packages/aws": {
             "resolved": "../packages/aws",
+            "link": true
+        },
+        "node_modules/@packages/business": {
+            "resolved": "../packages/business",
             "link": true
         },
         "node_modules/@packages/user": {
@@ -361,6 +373,10 @@
     "dependencies": {
         "@packages/aws": {
             "version": "file:../packages/aws"
+        },
+        "@packages/business": {
+            "version": "file:../packages/business",
+            "requires": {}
         },
         "@packages/user": {
             "version": "file:../packages/user",

--- a/src/server/src/product/ServerClass.ts
+++ b/src/server/src/product/ServerClass.ts
@@ -1,7 +1,8 @@
 import S3 from 'aws-sdk/clients/s3';
 import { creds } from '@packages/aws';
-import { UtiLClass } from '@packages/util';
+import { UtiLClass, Optional } from '@packages/util';
 import { UserClass } from '@packages/user';
+import { BusinessClass } from '@packages/business';
 
 import { ExpressReceiver } from '@slack/bolt';
 
@@ -18,6 +19,10 @@ class ServerClass {
         const u = new UserClass();
         u.loader();
         s3.getObject(undefined);
+    }
+
+    private async testMethod(): Promise<Optional<BusinessClass>> {
+        return new UserClass().userMethod();
     }
 }
 

--- a/src/server/tsconfig.esm.json
+++ b/src/server/tsconfig.esm.json
@@ -6,6 +6,7 @@
     },
     "references": [
         { "path": "../packages/user/tsconfig.esm.json" },
+        { "path": "../packages/business/tsconfig.esm.json" },
         { "path": "../packages/util/tsconfig.esm.json" }
     ],
     "exclude": ["dist/", "node_modules/", "src/**/*.*.test.*", "jest.config.ts"]

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -12,6 +12,7 @@
     },
     "references": [
         { "path": "../packages/aws" },
+        { "path": "../packages/business" },
         { "path": "../packages/user" },
         { "path": "../packages/util" }
     ]


### PR DESCRIPTION
@amcasey simplified the repo a bit and fixed some stuff you pointed out as I was trying to reproduce a new issue am facing in my real repo, no luck though. 
What's happening is am getting results in node_modules when searching for references (some or all):

In my real repo, when searching for `UtiLClass` references, included in the results are the `UtiLClass` and corresponding `index.ts` file inside the `node_modules` directory of the project it's searching in ie sample results:

```
UtiLClass src\packages\business\node_modules\@packages\util\src\core\util.ts
index.ts src\packages\business\node_modules\@packages\util\src\core
....actual results in the business package...
UtiLClass src\packages\user\node_modules\@packages\util\src\core\util.ts
index.ts src\packages\user\node_modules\@packages\util\src\core
....actual results in the user package....
```
Question is why is it even looking in node_modules in the first place when looking for references? Did I miss an exclude somewhere? The excludes are inherited from the `root` package so they become relative - is this an issue?

```
aws-sdk-test/src/packages/business
$ npx tsc --showConfig
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
{
    "compilerOptions": {
        "moduleResolution": "node",
        "isolatedModules": true,
        "resolveJsonModule": true,
        "allowSyntheticDefaultImports": true,
        "esModuleInterop": true,
        "skipLibCheck": true,
        "forceConsistentCasingInFileNames": true,
        "experimentalDecorators": true,
        "composite": true,
        "declaration": true,
        "incremental": true,
        "downlevelIteration": true,
        "declarationMap": true,
        "baseUrl": "../../..",
        "paths": {
            "@packages/*": [
                "./src/packages/*/"
            ]
        },
        "module": "commonjs",
        "target": "es2019",
        "allowJs": true,
        "preserveSymlinks": true,
        "outDir": "./dist",
        "rootDir": "./src"
    },
    "references": [
        {
            "path": "../util"
        }
    ],
    "files": [
        "./src/BusinessClass.ts",
        "./src/index.ts"
    ],
    "include": [
        "src/**/*"
    ],
    "exclude": [
        "../../../node_modules",
        "../../../**/node_modules",
        "../../../**/dist",
        "../../../dist"
    ]
}
```

Worth opening an new issue for this? Having trouble reproducing though, everything here seems the same as live.